### PR TITLE
fix bad namespacing when calling makedirs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ class BuildProtobuf(build):
     def run(self):
         if not path.exists("src/cld_3/protos"):
             # Create protobufs dir
-            os.makedirs("src/cld_3/protos")
+            makedirs("src/cld_3/protos")
 
         # Build protobuf stuff
         command = ["protoc"]


### PR DESCRIPTION
top import is `from os import path, makedirs` but the call to `makedirs` is under the `os` namespace. Which causes an error when trying to install